### PR TITLE
port to d3v4

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -25,8 +25,9 @@
       // const constructedMatrix = [];
       var matrix = [];
       var edgeHash = {};
-      var xScale = d3.scale.linear().domain([0, nodes.length]).range([0, width]);
-      var yScale = d3.scale.linear().domain([0, nodes.length]).range([0, height]);
+      var xScale = d3.scaleLinear().domain([0, nodes.length]).range([0, width]);
+
+      var yScale = d3.scaleLinear().domain([0, nodes.length]).range([0, height]);
 
       nodes.forEach(function (node, i) {
         node.sortedIndex = i;
@@ -145,17 +146,17 @@
     };
 
     matrix.xAxis = function (calledG) {
-      var nameScale = d3.scale.ordinal().domain(nodes.map(nodeID)).rangePoints([0, size[0]], 1);
+      var nameScale = d3.scalePoint().domain(nodes.map(nodeID)).range([0, size[0]]).padding(1);
 
-      var xAxis = d3.svg.axis().scale(nameScale).orient('top').tickSize(4);
+      var xAxis = d3.axisTop().scale(nameScale).tickSize(4);
 
       calledG.append('g').attr('class', 'am-xAxis am-axis').call(xAxis).selectAll('text').style('text-anchor', 'end').attr('transform', 'translate(-10,-10) rotate(90)');
     };
 
     matrix.yAxis = function (calledG) {
-      var nameScale = d3.scale.ordinal().domain(nodes.map(nodeID)).rangePoints([0, size[1]], 1);
+      var nameScale = d3.scalePoint().domain(nodes.map(nodeID)).range([0, size[1]]).padding(1);
 
-      var yAxis = d3.svg.axis().scale(nameScale).orient('left').tickSize(4);
+      var yAxis = d3.axisLeft().scale(nameScale).tickSize(4);
 
       calledG.append('g').attr('class', 'am-yAxis am-axis').call(yAxis);
     };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "build/bundle.js",
   "scripts": {
     "prepublish": "rm -rf build && mkdir build && rollup -c --banner \"$(preamble)\" -- index.js",
-    "test": "rm -rf build && mkdir build && rollup -c --banner \"$(preamble)\" -- index.js && cp build/bundle.js ~/workspace/d3-adjacency-layout-example-project/02-v3-es2015-bundle",
+    "test": "rm -rf build && mkdir build && rollup -c --banner \"$(preamble)\" -- index.js && cp build/bundle.js ~/workspace/d3-adjacency-layout-example-project/02-v3-es2015-bundle && cp build/bundle.js ~/workspace/d3-adjacency-layout-example-project/03-v4-es2015-bundle",
     "lint": "eslint index.js src --fix"
   },
   "repository": {

--- a/src/d3AdjacencyMatrixLayout.js
+++ b/src/d3AdjacencyMatrixLayout.js
@@ -16,8 +16,13 @@ export default function () {
     // const constructedMatrix = [];
     const matrix = [];
     const edgeHash = {};
-    const xScale = d3.scale.linear().domain([0, nodes.length]).range([0, width]);
-    const yScale = d3.scale.linear().domain([0, nodes.length]).range([0, height]);
+    const xScale = d3.scaleLinear()
+      .domain([0, nodes.length])
+      .range([0, width]);
+
+    const yScale = d3.scaleLinear()
+      .domain([0, nodes.length])
+      .range([0, height]);
 
     nodes.forEach((node, i) => {
       node.sortedIndex = i;
@@ -135,33 +140,37 @@ export default function () {
   };
 
   matrix.xAxis = calledG => {
-    const nameScale = d3.scale.ordinal()
-    .domain(nodes.map(nodeID))
-    .rangePoints([0, size[0]], 1);
+    const nameScale = d3.scalePoint()
+      .domain(nodes.map(nodeID))
+      .range([0, size[0]])
+      .padding(1);
 
-    const xAxis = d3.svg.axis().scale(nameScale).orient('top').tickSize(4);
+    const xAxis = d3.axisTop()
+      .scale(nameScale)
+      .tickSize(4);
 
     calledG
-    .append('g')
-    .attr('class', 'am-xAxis am-axis')
-    .call(xAxis)
-    .selectAll('text')
-    .style('text-anchor', 'end')
-    .attr('transform', 'translate(-10,-10) rotate(90)');
+      .append('g')
+      .attr('class', 'am-xAxis am-axis')
+      .call(xAxis)
+      .selectAll('text')
+      .style('text-anchor', 'end')
+      .attr('transform', 'translate(-10,-10) rotate(90)');
   };
 
   matrix.yAxis = calledG => {
-    const nameScale = d3.scale.ordinal()
-    .domain(nodes.map(nodeID))
-    .rangePoints([0, size[1]], 1);
+    const nameScale = d3.scalePoint()
+      .domain(nodes.map(nodeID))
+      .range([0, size[1]])
+      .padding(1);
 
-    const yAxis = d3.svg.axis().scale(nameScale)
-    .orient('left')
-    .tickSize(4);
+    const yAxis = d3.axisLeft()
+      .scale(nameScale)
+      .tickSize(4);
 
     calledG.append('g')
-    .attr('class', 'am-yAxis am-axis')
-    .call(yAxis);
+      .attr('class', 'am-yAxis am-axis')
+      .call(yAxis);
   };
 
   return matrix;


### PR DESCRIPTION
this PR ports the adjacency matrix layout to [d3v4](https://github.com/d3/d3/blob/master/CHANGES.md)

here is [an example](https://github.com/micahstubbs/d3-adjacency-layout-example-project/tree/master/03-v4-es2015-bundle) that uses this layout with d3v4
